### PR TITLE
Added LRANGE command and multi port support. 

### DIFF
--- a/django_cluster_redis/cache.py
+++ b/django_cluster_redis/cache.py
@@ -15,7 +15,7 @@ class ClusterRedis(StrictRedis):
             # parse out the address and port number
             msg_split = msg.rsplit(' ')[2].rsplit(":")
             host = msg_split[0]
-            port = msg.split[1]
+            port = msg_split[1]
            
             self._follow_redirect(host, port)
 

--- a/django_cluster_redis/cache.py
+++ b/django_cluster_redis/cache.py
@@ -13,19 +13,22 @@ class ClusterRedis(StrictRedis):
                 raise e
 
             # parse out the address
-            host = msg.rsplit(' ')[2].rsplit(':')[0]
-
-            self._follow_redirect(host)
+            host = msg.rsplit(' ')[2].rsplit(":")[0]
+            port = msg.rsplit(' ')[2].rsplit(":")[1]
+           
+            self._follow_redirect(host, port)
 
             return method(*args, **kwargs)
 
-    def _follow_redirect(self, host):
+    def _follow_redirect(self, host, port):
         pool = self.connection_pool
 
         pool.connection_kwargs['host'] = host
+        pool.connection_kwargs['port'] = port
         available_connections = pool._available_connections
+
         # find existing connection to reuse - redis always pops off the last connection
-        connection = [c for c in available_connections if c.host == host]
+        connection = [c for c in available_connections if c.host == host and c.port == int(port)]
 
         if connection:
             connection = connection[0]
@@ -112,3 +115,6 @@ class ClusterRedis(StrictRedis):
 
     def restore(self, *args, **kwargs):
         return self._action('restore', *args, **kwargs)
+
+    def lrange(self, *args, **kwargs): 
+        return self._action('lrange', *args, **kwargs)

--- a/django_cluster_redis/cache.py
+++ b/django_cluster_redis/cache.py
@@ -118,3 +118,6 @@ class ClusterRedis(StrictRedis):
 
     def lrange(self, *args, **kwargs): 
         return self._action('lrange', *args, **kwargs)
+
+    def lpush(self, *args, **kwargs): 
+        return self._action('lpush', *args, **kwargs)

--- a/django_cluster_redis/cache.py
+++ b/django_cluster_redis/cache.py
@@ -12,9 +12,10 @@ class ClusterRedis(StrictRedis):
             if 'MOVED' not in msg:
                 raise e
 
-            # parse out the address
-            host = msg.rsplit(' ')[2].rsplit(":")[0]
-            port = msg.rsplit(' ')[2].rsplit(":")[1]
+            # parse out the address and port number
+            msg_split = msg.rsplit(' ')[2].rsplit(":")
+            host = msg_split[0]
+            port = msg_split[1]
            
             self._follow_redirect(host, port)
 

--- a/django_cluster_redis/cache.py
+++ b/django_cluster_redis/cache.py
@@ -12,9 +12,10 @@ class ClusterRedis(StrictRedis):
             if 'MOVED' not in msg:
                 raise e
 
-            # parse out the address
-            host = msg.rsplit(' ')[2].rsplit(":")[0]
-            port = msg.rsplit(' ')[2].rsplit(":")[1]
+            # parse out the address and port number
+            msg_split = msg.rsplit(' ')[2].rsplit(":")
+            host = msg_split[0]
+            port = msg.split[1]
            
             self._follow_redirect(host, port)
 


### PR DESCRIPTION
Added support for the LRANGE command (I needed it).

Added support for multiple ports on the same host (e.g. 127.0.0.1). This was necessary as my testing cluster was on multiple ports of localhost, but will also support REDIS deployments where multiple instances are run on the same server to take advantage of multi-core systems as REDIS is single-threaded.